### PR TITLE
fix: reset allocator before KV sizing

### DIFF
--- a/src/sparsevllm/engine/model_runner.py
+++ b/src/sparsevllm/engine/model_runner.py
@@ -73,6 +73,14 @@ TP_RPC_STATUS_SYNC_METHODS = PREFIX_CACHE_CONTROL_RPC_METHODS | {
 def make_tp_shm_name() -> str:
     return f"{TP_SHM_NAME_PREFIX}{os.getpid()}_{uuid.uuid4().hex}"
 
+
+def _prepare_allocator_for_kv_sizing(platform, device: torch.device) -> None:
+    """Discard model-load temporaries before measuring the KV cache budget."""
+    platform.synchronize()
+    platform.empty_cache()
+    platform.reset_peak_memory_stats(device)
+
+
 class ModelRunner:
     """
     负责模型执行的类。每个 GPU Rank 进程都拥有一个 ModelRunner 实例。
@@ -198,6 +206,10 @@ class ModelRunner:
                 platform=self.platform,
                 state_spec=state_spec,
             )
+        # Model loading and backend warmup can leave released temporary tensors in
+        # the allocator cache. Flush them before KV sizing so device-used memory
+        # and allocator peak history do not reserve the same temporary memory.
+        _prepare_allocator_for_kv_sizing(self.platform, self.device)
         # Recurrent rows are persistent runtime state. Allocate them before the
         # cache manager sizes KV so gpu_memory_utilization accounts for both.
         self.cache_manager = CacheManager.create(config, self.parallel_context)

--- a/src/sparsevllm/engine/model_runner.py
+++ b/src/sparsevllm/engine/model_runner.py
@@ -74,13 +74,6 @@ def make_tp_shm_name() -> str:
     return f"{TP_SHM_NAME_PREFIX}{os.getpid()}_{uuid.uuid4().hex}"
 
 
-def _prepare_allocator_for_kv_sizing(platform, device: torch.device) -> None:
-    """Discard model-load temporaries before measuring the KV cache budget."""
-    platform.synchronize()
-    platform.empty_cache()
-    platform.reset_peak_memory_stats(device)
-
-
 class ModelRunner:
     """
     负责模型执行的类。每个 GPU Rank 进程都拥有一个 ModelRunner 实例。
@@ -209,7 +202,9 @@ class ModelRunner:
         # Model loading and backend warmup can leave released temporary tensors in
         # the allocator cache. Flush them before KV sizing so device-used memory
         # and allocator peak history do not reserve the same temporary memory.
-        _prepare_allocator_for_kv_sizing(self.platform, self.device)
+        self.platform.synchronize()
+        self.platform.empty_cache()
+        self.platform.reset_peak_memory_stats(self.device)
         # Recurrent rows are persistent runtime state. Allocate them before the
         # cache manager sizes KV so gpu_memory_utilization accounts for both.
         self.cache_manager = CacheManager.create(config, self.parallel_context)

--- a/tests/test_qwen35_mixed_runtime.py
+++ b/tests/test_qwen35_mixed_runtime.py
@@ -17,7 +17,7 @@ from sparsevllm.engine.cache_manager.base import (
 from sparsevllm.engine.cache_manager.quest import QuestCacheManager, QuestPrefixBlockPayload
 from sparsevllm.engine.cache_manager.snapkv import SnapKVCacheManager
 from sparsevllm.engine.cache_manager.standard import StandardCacheManager
-from sparsevllm.engine.model_runner import ModelRunner
+from sparsevllm.engine.model_runner import ModelRunner, _prepare_allocator_for_kv_sizing
 from sparsevllm.engine.prefix_cache import PrefixCacheBlock, RadixPrefixIndex
 from sparsevllm.engine.prefix_cache_coordinator import MixedPrefixBlockPayload, PrefixCacheCoordinator
 from sparsevllm.engine.recurrent_state_manager import (
@@ -714,6 +714,26 @@ def test_model_runner_resets_inherited_allocator_peak_before_model_construction(
 
     assert events == [("reset_peak", torch.device("cpu"))]
     assert observed_peak_at_construction == [0]
+
+
+def test_model_runner_flushes_allocator_before_kv_sizing():
+    events = []
+    device = torch.device("cpu")
+    platform = SimpleNamespace(
+        synchronize=lambda: events.append("synchronize"),
+        empty_cache=lambda: events.append("empty_cache"),
+        reset_peak_memory_stats=lambda observed_device: events.append(
+            ("reset_peak", observed_device)
+        ),
+    )
+
+    _prepare_allocator_for_kv_sizing(platform, device)
+
+    assert events == [
+        "synchronize",
+        "empty_cache",
+        ("reset_peak", device),
+    ]
 
 
 def test_cache_budget_resolves_joint_prefix_capacity_before_kv_allocation():

--- a/tests/test_qwen35_mixed_runtime.py
+++ b/tests/test_qwen35_mixed_runtime.py
@@ -17,7 +17,7 @@ from sparsevllm.engine.cache_manager.base import (
 from sparsevllm.engine.cache_manager.quest import QuestCacheManager, QuestPrefixBlockPayload
 from sparsevllm.engine.cache_manager.snapkv import SnapKVCacheManager
 from sparsevllm.engine.cache_manager.standard import StandardCacheManager
-from sparsevllm.engine.model_runner import ModelRunner, _prepare_allocator_for_kv_sizing
+from sparsevllm.engine.model_runner import ModelRunner
 from sparsevllm.engine.prefix_cache import PrefixCacheBlock, RadixPrefixIndex
 from sparsevllm.engine.prefix_cache_coordinator import MixedPrefixBlockPayload, PrefixCacheCoordinator
 from sparsevllm.engine.recurrent_state_manager import (
@@ -714,26 +714,6 @@ def test_model_runner_resets_inherited_allocator_peak_before_model_construction(
 
     assert events == [("reset_peak", torch.device("cpu"))]
     assert observed_peak_at_construction == [0]
-
-
-def test_model_runner_flushes_allocator_before_kv_sizing():
-    events = []
-    device = torch.device("cpu")
-    platform = SimpleNamespace(
-        synchronize=lambda: events.append("synchronize"),
-        empty_cache=lambda: events.append("empty_cache"),
-        reset_peak_memory_stats=lambda observed_device: events.append(
-            ("reset_peak", observed_device)
-        ),
-    )
-
-    _prepare_allocator_for_kv_sizing(platform, device)
-
-    assert events == [
-        "synchronize",
-        "empty_cache",
-        ("reset_peak", device),
-    ]
 
 
 def test_cache_budget_resolves_joint_prefix_capacity_before_kv_allocation():


### PR DESCRIPTION
## 改动内容

>[!NOTE]
>仅为低风险的临时修复方案

- 在计算 KV Cache 容量前等待设备上的异步任务完成
- 清理模型加载和后端预热遗留的非活跃分配器缓存
- 在常驻显存边界处重置分配器峰值统计

## 问题根因

KV 容量计算同时使用了设备当前显存占用和 PyTorch 分配器的历史峰值。模型加载期间产生的临时 Tensor 即使已经释放，也可能继续保留在缓存分配器中，导致同一部分临时显存同时影响两套统计口径，从而使 KV slot 容量估计过于保守。

本次改动在创建 CacheManager 前建立一个干净的测量边界。这是一个范围较小的临时修复；后续可以单独加入显式的 activation 和 workspace profiling。

## 影响

KV Cache 容量计算不再继承模型加载阶段的历史临时峰值。模型权重和 recurrent state 等常驻分配仍会正常计入容量计算。

## 验证

### 单元测试

- `pytest -q tests/test_qwen35_mixed_runtime.py -k "model_runner_resets_inherited_allocator_peak_before_model_construction or kv_available_bytes"`：3 passed
- `git diff --check`

### 实机验证

在 4×H20、MiniMax-M2.7、4 个 EP rank 的环境中完成验证。测试时未合并本 PR，仅手工迁移了 KV sizing 前的显存清理逻辑。

- 修改前：107,117 KV slots
- 修改后：108,042 KV slots
- 增加：925 slots，约 +0.864%
- 可分配 KV 显存增加：234,905,088 bytes，约 224 MiB
- 4 个 EP rank 的结果完全一致
- 定向测试：2 passed
- 完整启动、CUDA Graph warmup 和单样本推理均成功
- 测试结束后 4 张 GPU 均已恢复空闲