### PR TITLE
feat: 添加 tiny random 调试模式

### DIFF
--- a/configs/debug/qwen3_tiny_random.json
+++ b/configs/debug/qwen3_tiny_random.json
@@ -1,0 +1,9 @@
+{
+  "num_hidden_layers": 2,
+  "hidden_size": 1024,
+  "intermediate_size": 3072,
+  "num_attention_heads": 8,
+  "num_key_value_heads": 4,
+  "head_dim": 128,
+  "max_position_embeddings": 2048
+}

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -5,3 +5,4 @@ behavior.
 
 - [Core Sparse Methods](sparse-methods.md)
 - [DeltaKV](deltakv.md)
+- [Tiny Random Debug Mode](tiny-random-debug.md)

--- a/docs/features/tiny-random-debug.md
+++ b/docs/features/tiny-random-debug.md
@@ -1,0 +1,76 @@
+# Tiny Random Debug Mode
+
+Tiny random mode constructs a smaller model from the source checkpoint's
+`config.json` and initializes deterministic fake weights without reading any
+checkpoint tensor files. It is intended for model-development, tensor-parallel,
+prefill/decode, and numerical-alignment debugging. Its outputs do not represent
+model quality.
+
+The implementation lives in the opt-in
+`sparsevllm.debug.tiny_random` module. Normal inference does not import this
+module. The only core integration points are model configuration and
+startup-time weight initialization; scheduler, attention, cache, and model
+forward hot paths are unchanged.
+
+## Configuration
+
+Enable the mode with these environment variables:
+
+```bash
+export SPARSEVLLM_TINY_RANDOM=1
+export SPARSEVLLM_TINY_RANDOM_CONFIG="$PWD/configs/debug/qwen3_tiny_random.json"
+export SPARSEVLLM_TINY_RANDOM_SEED=17
+```
+
+The JSON override file accepts only:
+
+- `num_hidden_layers`
+- `hidden_size`
+- `intermediate_size`
+- `num_attention_heads`
+- `num_key_value_heads`
+- `head_dim`
+- `vocab_size`
+- `max_position_embeddings`
+
+`num_hidden_layers`, `hidden_size`, and `intermediate_size` are required and
+must not enlarge the source model. Invalid head dimensions and TP-incompatible
+attention heads, KV heads, or vocabulary sizes fail before model construction.
+The source model directory is still required for configuration and tokenizer
+metadata, but its `.safetensors` files are not opened.
+
+## Qwen3-8B two-GPU check
+
+Use the project-root uv environment:
+
+```bash
+CUDA_VISIBLE_DEVICES=5,6 \
+PYTHONPATH="$PWD:$PWD/src" \
+.venv/bin/python scripts/debug/compare_logits_hf_sparsevllm.py \
+  --model_path /data2/pretrain_models/Qwen3-8B \
+  --cases short \
+  --methods vanilla \
+  --tiny_random_config "$PWD/configs/debug/qwen3_tiny_random.json" \
+  --tiny_random_seed 17 \
+  --tensor_parallel_size 2 \
+  --max_model_len 2048 \
+  --engine_prefill_chunk_size 256 \
+  --max_num_batched_tokens 512 \
+  --max_num_seqs_in_batch 1 \
+  --max_decoding_seqs 1 \
+  --gpu_memory_utilization 0.02 \
+  --mlp_chunk_size 256 \
+  --teacher_forced_decode_steps 2 \
+  --output_dir /tmp/sparsevllm_tiny_random_qwen3_8b_tp2
+```
+
+The comparison script constructs the HF reference from the same reduced config
+and seed, then compares teacher-forced prefill and decode logits. Tiny-random HF
+comparison currently supports `vanilla` only.
+
+## Limitations
+
+- Quantized base-model weights are not supported.
+- Qwen3.5 mixed attention is not supported yet.
+- DeltaKV learned compressor weights are not supported.
+- This mode does not test checkpoint loading or downstream task quality.

--- a/scripts/debug/compare_logits_hf_sparsevllm.py
+++ b/scripts/debug/compare_logits_hf_sparsevllm.py
@@ -14,14 +14,14 @@ from typing import Any
 
 import torch
 import torch.multiprocessing as mp
-from transformers import AutoTokenizer
+from transformers import AutoConfig, AutoTokenizer
 
 from deltakv.configs.runtime_params import normalize_runtime_params
 from deltakv.configs.default_paths import compressor_path, model_path, output_path
 from deltakv.get_chat_api import get_generate_api
 from benchmark.long_bench.pred import build_chat
 from sparsevllm.config import Config
-from sparsevllm.engine.model_runner import ModelRunner
+from sparsevllm.engine.model_runner import ModelRunner, make_tp_shm_name
 from sparsevllm.engine.sequence import Sequence
 from sparsevllm.method_registry import (
     PREFILL_POLICY_ALL_CHUNKED,
@@ -29,6 +29,13 @@ from sparsevllm.method_registry import (
     is_deltakv_method,
 )
 from sparsevllm.sampling_params import SamplingParams
+from sparsevllm.debug.tiny_random import (
+    TINY_RANDOM_CONFIG_ENV,
+    TINY_RANDOM_ENV,
+    TINY_RANDOM_SEED_ENV,
+    apply_tiny_random_overrides,
+    build_tiny_random_hf_model,
+)
 from sparsevllm.utils.context import get_context, reset_context
 
 
@@ -1900,6 +1907,26 @@ def _sparse_infer_config(args: argparse.Namespace, method: str) -> dict[str, Any
 
 def _load_hf_model(args: argparse.Namespace, method: str, prompt_len: int):
     infer_config = _hf_infer_config(args, method, prompt_len)
+    if args.tiny_random_config:
+        if method != "vanilla":
+            raise NotImplementedError(
+                "Tiny random HF comparison currently supports --methods vanilla only."
+            )
+        config = AutoConfig.from_pretrained(args.model_path, trust_remote_code=True)
+        overrides = apply_tiny_random_overrides(config, args.tiny_random_config)
+        config._attn_implementation = "eager"
+        model = build_tiny_random_hf_model(
+            config,
+            seed=int(args.tiny_random_seed),
+        )
+        model.to(torch.device("cuda", 0))
+        model.eval()
+        return model, {
+            "weight_mode": "tiny_random",
+            "seed": int(args.tiny_random_seed),
+            "config_path": os.path.abspath(args.tiny_random_config),
+            "overrides": overrides,
+        }
     _, model = get_generate_api(
         model_path=args.model_path,
         infer_config=infer_config,
@@ -2023,14 +2050,18 @@ def _make_sparse_runner(args: argparse.Namespace, method: str) -> tuple[ModelRun
     processes = []
     events = []
     ctx = mp.get_context("spawn")
+    tp_shm_name = make_tp_shm_name() if config.world_size > 1 else None
     try:
         for rank in range(1, int(config.tensor_parallel_size)):
-            event = ctx.Event()
-            process = ctx.Process(target=ModelRunner, args=(config, rank, event))
+            event = (ctx.Event(), ctx.Event())
+            process = ctx.Process(
+                target=ModelRunner,
+                args=(config, rank, event, tp_shm_name),
+            )
             process.start()
             processes.append(process)
             events.append(event)
-        runner = ModelRunner(config, 0, events)
+        runner = ModelRunner(config, 0, events, tp_shm_name)
     except Exception:
         for process in processes:
             if process.is_alive():
@@ -3350,6 +3381,12 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--max_decoding_seqs", type=int, default=1)
     parser.add_argument("--max_num_batched_tokens", type=int, default=None)
     parser.add_argument("--tensor_parallel_size", type=int, default=1)
+    parser.add_argument(
+        "--tiny_random_config",
+        default=None,
+        help="JSON architecture overrides for deterministic random-weight comparison.",
+    )
+    parser.add_argument("--tiny_random_seed", type=int, default=0)
     return parser.parse_args()
 
 
@@ -3364,7 +3401,18 @@ def main() -> int:
 
     os.environ.setdefault("SPARSEVLLM_MASTER_PORT", str(args.master_port))
     _require_path(args.model_path, "model_path")
+    if args.tiny_random_config:
+        _require_path(args.tiny_random_config, "tiny_random_config")
+        if int(args.tiny_random_seed) < 0:
+            raise ValueError("--tiny_random_seed must be >= 0.")
+        os.environ[TINY_RANDOM_ENV] = "1"
+        os.environ[TINY_RANDOM_CONFIG_ENV] = os.path.abspath(args.tiny_random_config)
+        os.environ[TINY_RANDOM_SEED_ENV] = str(int(args.tiny_random_seed))
     methods = [part.strip() for part in args.methods.split(",") if part.strip()]
+    if args.tiny_random_config and set(methods) != {"vanilla"}:
+        raise NotImplementedError(
+            "Tiny random HF comparison currently requires --methods vanilla."
+        )
     uses_deltakv_compare = any(method in DELTAKV_COMPARE_METHODS for method in methods)
     if bool(args.use_compression) and uses_deltakv_compare:
         _require_path(args.compressor_path, "compressor_path")

--- a/src/sparsevllm/config.py
+++ b/src/sparsevllm/config.py
@@ -603,6 +603,10 @@ class Config:
     outer_hf_config: Any | None = None
     runtime_layout: RuntimeLayout | None = None
     quantization_config: QuantizationConfig = field(default_factory=QuantizationConfig.disabled)
+    tiny_random: bool = False
+    tiny_random_config: str | None = None
+    tiny_random_seed: int = 0
+    tiny_random_overrides: dict[str, int] = field(default_factory=dict, init=False)
     eos: int = -1
     eos_token_ids: tuple[int, ...] = field(default_factory=tuple)
     num_kvcache_slots: int | list = -1
@@ -792,6 +796,18 @@ class Config:
     def __post_init__(self):
         if os.getenv("PROFILER_SVLLM"):
             self.enable_profiler = True
+        if self.tiny_random or os.getenv("SPARSEVLLM_TINY_RANDOM") is not None:
+            from sparsevllm.debug.tiny_random import resolve_tiny_random_settings
+
+            (
+                self.tiny_random,
+                self.tiny_random_config,
+                self.tiny_random_seed,
+            ) = resolve_tiny_random_settings(
+                enabled=self.tiny_random,
+                config_path=self.tiny_random_config,
+                seed=self.tiny_random_seed,
+            )
 
         raw_sparse_method = self.vllm_sparse_method
         raw_sparse_method_normalized = "" if raw_sparse_method is None else str(raw_sparse_method).strip().lower()
@@ -1129,6 +1145,10 @@ class Config:
         if isinstance(self.deltakv_path, str):
             deltakv_path = self.deltakv_path.strip()
             self.deltakv_path = None if deltakv_path.lower() in {"", "none", "null"} else deltakv_path
+        if self.tiny_random and self.vllm_sparse_method == "deltakv":
+            raise NotImplementedError(
+                "Tiny random mode does not support DeltaKV compressor weights yet."
+            )
         try:
             self.outer_hf_config = AutoConfig.from_pretrained(self.model, trust_remote_code=True)
         except Exception as e:
@@ -1137,6 +1157,21 @@ class Config:
         self.hf_config = _extract_text_config(self.outer_hf_config)
         if is_qwen35:
             setattr(self.hf_config, "model_type", "qwen3_5")
+        if self.tiny_random:
+            from sparsevllm.debug.tiny_random import apply_tiny_random_overrides
+
+            if is_qwen35:
+                raise NotImplementedError("Tiny random mode does not support qwen3_5 yet.")
+            self.tiny_random_overrides = apply_tiny_random_overrides(
+                self.hf_config,
+                self.tiny_random_config,
+            )
+            log_once(
+                "TINY RANDOM MODE is enabled: checkpoint weights will not be read and "
+                f"model-quality results are invalid. config={self.tiny_random_config} "
+                f"seed={self.tiny_random_seed} overrides={self.tiny_random_overrides}",
+                level="WARNING",
+            )
         raw_quantization_config = _config_get(
             self.hf_config,
             "quantization_config",
@@ -1146,6 +1181,8 @@ class Config:
             raw_quantization_config,
             required_fp8=is_qwen35,
         )
+        if self.tiny_random and self.quantization_config.enabled:
+            raise NotImplementedError("Tiny random mode does not support quantized model weights.")
         setattr(self.hf_config, "quantization_config", self.quantization_config)
         if getattr(self.hf_config, "model_type", "") in {"deepseek_v2", "deepseek_v32"}:
             raise NotImplementedError(
@@ -1237,6 +1274,19 @@ class Config:
                 "Set allow_missing_deltakv_path=True only for construction-only tests."
             )
         self.runtime_layout = RuntimeLayout.from_config(self.hf_config, require_mixed=is_qwen35)
+        if self.tiny_random:
+            if self.hf_config.num_attention_heads % self.tensor_parallel_size != 0:
+                raise ValueError(
+                    "Tiny random num_attention_heads must be divisible by tensor_parallel_size."
+                )
+            if self.hf_config.num_key_value_heads % self.tensor_parallel_size != 0:
+                raise ValueError(
+                    "Tiny random num_key_value_heads must be divisible by tensor_parallel_size."
+                )
+            if self.hf_config.vocab_size % self.tensor_parallel_size != 0:
+                raise ValueError(
+                    "Tiny random vocab_size must be divisible by tensor_parallel_size."
+                )
         if self.max_model_len > self.hf_config.max_position_embeddings:
             logger.warning('max_model_len > model.max_position_embeddings 输出可能不正常')
             self.hf_config.max_position_embeddings = self.max_model_len

--- a/src/sparsevllm/debug/__init__.py
+++ b/src/sparsevllm/debug/__init__.py
@@ -1,0 +1,1 @@
+"""Opt-in debug helpers that are not imported by the inference hot path."""

--- a/src/sparsevllm/debug/tiny_random.py
+++ b/src/sparsevllm/debug/tiny_random.py
@@ -1,0 +1,223 @@
+import copy
+import json
+import os
+from contextlib import contextmanager
+from typing import Any, Iterator
+
+import torch
+from torch import nn
+
+
+TINY_RANDOM_ENV = "SPARSEVLLM_TINY_RANDOM"
+TINY_RANDOM_CONFIG_ENV = "SPARSEVLLM_TINY_RANDOM_CONFIG"
+TINY_RANDOM_SEED_ENV = "SPARSEVLLM_TINY_RANDOM_SEED"
+
+SUPPORTED_OVERRIDES = frozenset(
+    {
+        "head_dim",
+        "hidden_size",
+        "intermediate_size",
+        "max_position_embeddings",
+        "num_attention_heads",
+        "num_hidden_layers",
+        "num_key_value_heads",
+        "vocab_size",
+    }
+)
+
+
+def env_flag(name: str, default: bool = False) -> bool:
+    raw = os.getenv(name)
+    if raw is None:
+        return bool(default)
+    normalized = raw.strip().lower()
+    if normalized in {"1", "true", "yes", "on"}:
+        return True
+    if normalized in {"0", "false", "no", "off"}:
+        return False
+    raise ValueError(f"{name} must be an explicit boolean, got {raw!r}.")
+
+
+def resolve_tiny_random_settings(
+    *,
+    enabled: bool,
+    config_path: str | None,
+    seed: int,
+) -> tuple[bool, str | None, int]:
+    resolved_enabled = env_flag(TINY_RANDOM_ENV, enabled)
+    resolved_path = os.getenv(TINY_RANDOM_CONFIG_ENV, config_path)
+    resolved_seed_raw = os.getenv(TINY_RANDOM_SEED_ENV)
+    resolved_seed = int(resolved_seed_raw) if resolved_seed_raw is not None else int(seed)
+    if resolved_seed < 0:
+        raise ValueError(f"tiny_random_seed must be >= 0, got {resolved_seed}.")
+    if resolved_enabled:
+        if not resolved_path:
+            raise ValueError(
+                f"tiny random mode requires a JSON override file via "
+                f"{TINY_RANDOM_CONFIG_ENV} or tiny_random_config."
+            )
+        resolved_path = os.path.abspath(os.path.expanduser(resolved_path))
+        if not os.path.isfile(resolved_path):
+            raise FileNotFoundError(f"Tiny random config does not exist: {resolved_path}")
+    return resolved_enabled, resolved_path, resolved_seed
+
+
+def load_tiny_random_overrides(path: str) -> dict[str, int]:
+    with open(path, "r", encoding="utf-8") as f:
+        raw = json.load(f)
+    if not isinstance(raw, dict):
+        raise TypeError(f"Tiny random config must contain one JSON object, got {type(raw).__name__}.")
+    unknown = sorted(set(raw) - SUPPORTED_OVERRIDES)
+    if unknown:
+        raise ValueError(
+            f"Unsupported tiny random config keys: {unknown}. "
+            f"Allowed keys: {sorted(SUPPORTED_OVERRIDES)}."
+        )
+    required = {"num_hidden_layers", "hidden_size", "intermediate_size"}
+    missing = sorted(required - set(raw))
+    if missing:
+        raise ValueError(f"Tiny random config is missing required shrink overrides: {missing}.")
+    overrides: dict[str, int] = {}
+    for name, value in raw.items():
+        if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+            raise ValueError(f"Tiny random override {name} must be a positive integer, got {value!r}.")
+        overrides[name] = int(value)
+    return overrides
+
+
+def apply_tiny_random_overrides(hf_config: Any, path: str) -> dict[str, int]:
+    overrides = load_tiny_random_overrides(path)
+    original_values = {
+        name: int(getattr(hf_config, name))
+        for name in overrides
+        if hasattr(hf_config, name)
+    }
+    for name, value in overrides.items():
+        if not hasattr(hf_config, name):
+            raise ValueError(
+                f"Tiny random override {name!r} is not present on "
+                f"{type(hf_config).__name__}."
+            )
+        setattr(hf_config, name, value)
+    for name in ("num_hidden_layers", "hidden_size", "intermediate_size"):
+        if overrides[name] > original_values[name]:
+            raise ValueError(
+                f"Tiny random override {name} must not enlarge the source model: "
+                f"{overrides[name]} > {original_values[name]}."
+            )
+
+    layer_types = getattr(hf_config, "layer_types", None)
+    if layer_types is not None:
+        num_layers = int(hf_config.num_hidden_layers)
+        if len(layer_types) < num_layers:
+            raise ValueError(
+                "Tiny random config cannot expand layer_types: "
+                f"requested={num_layers}, available={len(layer_types)}."
+            )
+        hf_config.layer_types = list(layer_types[:num_layers])
+
+    hidden_size = int(hf_config.hidden_size)
+    num_heads = int(hf_config.num_attention_heads)
+    num_kv_heads = int(hf_config.num_key_value_heads)
+    head_dim = int(getattr(hf_config, "head_dim", hidden_size // num_heads))
+    if hidden_size != num_heads * head_dim:
+        raise ValueError(
+            "Tiny random config requires hidden_size == num_attention_heads * head_dim, "
+            f"got {hidden_size} != {num_heads} * {head_dim}."
+        )
+    if num_heads % num_kv_heads != 0:
+        raise ValueError(
+            "Tiny random config requires num_attention_heads divisible by "
+            f"num_key_value_heads, got {num_heads} % {num_kv_heads}."
+        )
+    return overrides
+
+
+@contextmanager
+def _cpu_default_dtype(dtype: torch.dtype) -> Iterator[None]:
+    previous_dtype = torch.get_default_dtype()
+    try:
+        torch.set_default_dtype(dtype)
+        with torch.device("cpu"):
+            yield
+    finally:
+        torch.set_default_dtype(previous_dtype)
+
+
+def build_tiny_random_hf_model(
+    hf_config: Any,
+    *,
+    seed: int,
+) -> nn.Module:
+    from transformers import AutoModelForCausalLM
+
+    config = copy.deepcopy(hf_config)
+    dtype = getattr(config, "torch_dtype", None)
+    if dtype not in {torch.float16, torch.bfloat16, torch.float32}:
+        raise TypeError(f"Tiny random mode requires a floating torch_dtype, got {dtype!r}.")
+    with torch.random.fork_rng(devices=[]):
+        torch.manual_seed(int(seed))
+        with _cpu_default_dtype(dtype):
+            model = AutoModelForCausalLM.from_config(config, trust_remote_code=True)
+    model.eval()
+    return model
+
+
+def initialize_sparse_model(
+    model: nn.Module,
+    hf_config: Any,
+    *,
+    seed: int,
+) -> None:
+    from sparsevllm.utils.loader import (
+        _target_weight_name_for_model,
+        default_weight_loader,
+    )
+
+    reference = build_tiny_random_hf_model(hf_config, seed=seed)
+    packed_modules_mapping = getattr(model, "packed_modules_mapping", {})
+    loaded_count = 0
+    loaded_parameter_names: set[str] = set()
+    try:
+        for source_weight_name, loaded_weight in reference.state_dict().items():
+            param_name = _target_weight_name_for_model(model, source_weight_name)
+            if param_name is None:
+                continue
+            special_loader = getattr(model, "load_special_weight", None)
+            special_suffixes = tuple(getattr(model, "special_weight_loaders", ()))
+            if callable(special_loader) and param_name.endswith(special_suffixes):
+                special_count = int(special_loader(param_name, loaded_weight, None))
+                if special_count < 0:
+                    raise ValueError(
+                        f"load_special_weight() returned a negative count for {param_name!r}."
+                    )
+                if special_count:
+                    loaded_count += special_count
+                    continue
+            for source_name, (packed_name, shard_id) in packed_modules_mapping.items():
+                if source_name in param_name:
+                    packed_param_name = param_name.replace(source_name, packed_name)
+                    param = model.get_parameter(packed_param_name)
+                    weight_loader = getattr(param, "weight_loader")
+                    weight_loader(param, loaded_weight, shard_id)
+                    loaded_parameter_names.add(packed_param_name)
+                    loaded_count += 1
+                    break
+            else:
+                param = model.get_parameter(param_name)
+                weight_loader = getattr(param, "weight_loader", default_weight_loader)
+                weight_loader(param, loaded_weight)
+                loaded_parameter_names.add(param_name)
+                loaded_count += 1
+    finally:
+        del reference
+
+    if loaded_count <= 0:
+        raise RuntimeError("Tiny random initialization did not load any parameters.")
+    strict_validator = getattr(model, "validate_loaded_weights", None)
+    if callable(strict_validator):
+        strict_validator(loaded_parameter_names)
+    print(
+        f"Initialized {loaded_count} model weights from deterministic tiny random "
+        f"seed={int(seed)} without reading checkpoint tensors"
+    )

--- a/src/sparsevllm/engine/model_runner.py
+++ b/src/sparsevllm/engine/model_runner.py
@@ -158,12 +158,21 @@ class ModelRunner:
             self.model = LlamaForCausalLM(hf_config)
         else:
             raise NotImplementedError(f"Unsupported Sparse-vLLM model_type={hf_config.model_type!r}.")
-        load_model(
-            self.model,
-            config.model,
-            tp_rank=self.parallel_context.tp_rank,
-            tp_size=self.parallel_context.tp_size,
-        )
+        if config.tiny_random:
+            from sparsevllm.debug.tiny_random import initialize_sparse_model
+
+            initialize_sparse_model(
+                self.model,
+                hf_config,
+                seed=config.tiny_random_seed,
+            )
+        else:
+            load_model(
+                self.model,
+                config.model,
+                tp_rank=self.parallel_context.tp_rank,
+                tp_size=self.parallel_context.tp_size,
+            )
         if hf_config.model_type == "qwen3_moe" and config.moe_backend == "triton":
             self.model.warmup_moe_backend()
         

--- a/tests/test_tiny_random.py
+++ b/tests/test_tiny_random.py
@@ -1,0 +1,112 @@
+import json
+import os
+import subprocess
+import sys
+
+import pytest
+import torch
+from transformers import Qwen3Config
+
+from sparsevllm.debug.tiny_random import (
+    apply_tiny_random_overrides,
+    build_tiny_random_hf_model,
+    load_tiny_random_overrides,
+    resolve_tiny_random_settings,
+)
+
+
+def _write_overrides(tmp_path, **updates):
+    values = {
+        "num_hidden_layers": 2,
+        "hidden_size": 64,
+        "intermediate_size": 128,
+        "num_attention_heads": 4,
+        "num_key_value_heads": 2,
+        "head_dim": 16,
+        "vocab_size": 128,
+        "max_position_embeddings": 128,
+    }
+    values.update(updates)
+    path = tmp_path / "tiny.json"
+    path.write_text(json.dumps(values), encoding="utf-8")
+    return path
+
+
+def _qwen3_config():
+    return Qwen3Config(
+        num_hidden_layers=4,
+        hidden_size=128,
+        intermediate_size=256,
+        num_attention_heads=8,
+        num_key_value_heads=4,
+        head_dim=16,
+        vocab_size=256,
+        max_position_embeddings=256,
+        torch_dtype=torch.bfloat16,
+    )
+
+
+def test_tiny_random_overrides_are_applied(tmp_path):
+    path = _write_overrides(tmp_path)
+    config = _qwen3_config()
+
+    overrides = apply_tiny_random_overrides(config, str(path))
+
+    assert overrides["num_hidden_layers"] == 2
+    assert config.hidden_size == 64
+    assert config.num_attention_heads == 4
+    assert config.head_dim == 16
+    assert len(config.layer_types) == 2
+
+
+def test_tiny_random_rejects_unknown_override(tmp_path):
+    path = _write_overrides(tmp_path, model_type="llama")
+
+    with pytest.raises(ValueError, match="Unsupported tiny random config keys"):
+        load_tiny_random_overrides(str(path))
+
+
+def test_tiny_random_requires_config_when_enabled(monkeypatch):
+    monkeypatch.delenv("SPARSEVLLM_TINY_RANDOM_CONFIG", raising=False)
+
+    with pytest.raises(ValueError, match="requires a JSON override file"):
+        resolve_tiny_random_settings(enabled=True, config_path=None, seed=0)
+
+
+def test_tiny_random_hf_initialization_is_deterministic(tmp_path):
+    path = _write_overrides(tmp_path)
+    config = _qwen3_config()
+    apply_tiny_random_overrides(config, str(path))
+
+    first = build_tiny_random_hf_model(config, seed=17)
+    second = build_tiny_random_hf_model(config, seed=17)
+    third = build_tiny_random_hf_model(config, seed=18)
+    first_state = first.state_dict()
+    second_state = second.state_dict()
+    third_state = third.state_dict()
+
+    assert first_state.keys() == second_state.keys()
+    assert all(torch.equal(first_state[name], second_state[name]) for name in first_state)
+    assert any(not torch.equal(first_state[name], third_state[name]) for name in first_state)
+
+
+def test_normal_config_import_does_not_import_tiny_random_module():
+    env = dict(os.environ)
+    env.pop("SPARSEVLLM_TINY_RANDOM", None)
+    env.pop("SPARSEVLLM_TINY_RANDOM_CONFIG", None)
+    env.pop("SPARSEVLLM_TINY_RANDOM_SEED", None)
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            (
+                "import sys; import sparsevllm.config; "
+                "assert 'sparsevllm.debug.tiny_random' not in sys.modules"
+            ),
+        ],
+        check=False,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode == 0, completed.stderr


### PR DESCRIPTION
## 背景

当前开发和数值调试需要完整模型 checkpoint。即使只想验证模型结构、TP 切分、prefill/decode 或 kernel 数值，也必须读取真实权重并承担完整模型的资源开销。

本 PR 增加一个显式 opt-in 的 tiny random 模式：读取原模型配置后应用缩小版 JSON override，并使用固定 seed 构造确定性假权重，不读取 checkpoint tensor。

## 改动

- 新增独立的 `sparsevllm.debug.tiny_random` 模块
  - 严格解析环境变量和缩小配置
  - 校验 layer/head/KV head/vocab 与 TP 的兼容性
  - 基于 HF `from_config` 生成确定性规范权重
  - 复用现有 weight loader 将权重装入 packed/TP 分片
- 在 `Config` 和 `ModelRunner` 的启动阶段增加惰性挂钩
  - 默认模式不导入 tiny-random 模块
  - 不修改 scheduler、attention、KV cache 和模型 forward 热路径
- 扩展 HF/Sparse-vLLM logits 对比脚本
  - 支持相同 tiny config 和 seed
  - 修复脚本的 TP shared-memory 启动参数
- 提供 Qwen3 tiny 配置示例、使用文档和单元测试

## 使用方式

```bash
export SPARSEVLLM_TINY_RANDOM=1
export SPARSEVLLM_TINY_RANDOM_CONFIG="$PWD/configs/debug/qwen3_tiny_random.json"
export SPARSEVLLM_TINY_RANDOM_SEED=17
```

模型目录仍用于读取 `config.json` 和 tokenizer metadata，但不会打开 `.safetensors` 权重文件。

## 验证

- `.venv` / uv 环境：`19 passed, 17 subtests passed`
- Qwen3-8B 缩小为 2 层、hidden size 1024
- GPU 5/6 上完成 TP=2 prefill 和两步 teacher-forced decode
- HF/Sparse-vLLM 的 prefill 与 decode argmax 全部一致
- 最大 logits 误差约为 0.027–0.033（BF16/TP kernel）
- 实际 OpenAI Chat Completions 请求完成 14 prompt tokens + 4 completion tokens

## 当前限制

- 暂不支持量化 base-model 权重
- 暂不支持 Qwen3.5 mixed attention
- 暂不支持 DeltaKV 学习型 compressor 权重
- HF 数值对比当前仅验证 vanilla
- 该模式用于实现调试，不代表真实模型质量，也不覆盖 checkpoint loader 正确性
